### PR TITLE
Add license line GPL

### DIFF
--- a/conjecture-mode.el
+++ b/conjecture-mode.el
@@ -3,6 +3,8 @@
 ;; Copyright © 2013 Paul Stadig
 ;; Copyright © 2009-2011 Phil Hagelberg
 
+;; License: GPL
+
 ;; Author: Paul Stadig <paul@stadig.name>
 ;; URL: http://emacswiki.org/cgi-bin/wiki/ConjectureMode
 ;; Version: 1.0


### PR DESCRIPTION
@tarsius PTAL

This is a little bit tricky. It is forked from a project where other files at the time of the making of the fork are GPLv3+. However the forked file is removed from that project and could be older then GPLv3+ and removed from the project due to these copyright issues. So stopping the analysis there I take the safe route and use just GPL here too.